### PR TITLE
feat: externalize model pricing

### DIFF
--- a/model_costs.json
+++ b/model_costs.json
@@ -1,0 +1,16 @@
+{
+  "gemini-2.5-flash": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 2.5e-6,
+    "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+  },
+  "imagen-4.0-fast-generate-001": {
+    "output_cost_per_image": 0.02,
+    "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+  }
+}


### PR DESCRIPTION
## Summary
- load model pricing from new `model_costs.json`
- track text-to-speech token usage and compute costs using selected models
- display token and image costs based on model-specific rates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9974150e88326ade28a31a4de7ef2