### PR TITLE
Ensure Windows API key is detected in virtualenvs

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -33,7 +33,12 @@ except ImportError:  # pragma: no cover - non-Windows
     winsound = None
 
 from models import Attributes, Environment, GameResponse, InventoryItem, PerkSkill
-from utils import clean_unicode, load_embedded_fonts, set_user_env_var
+from utils import (
+    clean_unicode,
+    load_embedded_fonts,
+    set_user_env_var,
+    get_user_env_var,
+)
 
 IMAGE_GENERATION_ENABLED = False
 SOUND_ENABLED = True
@@ -126,11 +131,16 @@ _STYLES, _DIFFICULTIES = _parse_world()
 world_text = ""
 
 # --- Gemini client setup ---
-api_key = os.environ.get("GEMINI_API_KEY")
+# Prefer an existing environment variable but fall back to the user's global
+# Windows environment settings (useful when running from a virtual
+# environment).
+api_key = os.environ.get("GEMINI_API_KEY") or get_user_env_var("GEMINI_API_KEY")
 if api_key:
+    # ensure downstream code can always rely on os.environ
+    os.environ["GEMINI_API_KEY"] = api_key
     client = genai.Client(api_key=api_key)
 else:
-    client=None
+    client = None
 
 # --- Main RPG application ---
 class RPGGame:

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ py -m venv .venv
 pip install -r requirements.txt
 $env:GEMINI_API_KEY="your_key_here"
 python NilsRPG.py
+```
+
+The application will automatically read your `GEMINI_API_KEY` from the Windows
+user environment, even when running inside a virtual environment. You can also
+configure or update the key from the in‑game **API** menu.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 import pytest
 
-from utils import clean_unicode, set_user_env_var, load_embedded_fonts
+from utils import clean_unicode, set_user_env_var, load_embedded_fonts, get_user_env_var
 
 
 def test_clean_unicode_removes_control_chars():
@@ -37,4 +37,16 @@ def test_load_embedded_fonts_noop_on_non_windows():
 
     # Should simply return without raising on non-Windows systems
     assert load_embedded_fonts() is None
+
+
+def test_get_user_env_var_reads_from_env(monkeypatch):
+    """On non-Windows platforms the helper falls back to os.environ."""
+
+    # Ensure variable missing initially
+    monkeypatch.delenv('TEST_VAR', raising=False)
+    assert get_user_env_var('TEST_VAR') is None
+
+    # When present in the environment it should be returned
+    monkeypatch.setenv('TEST_VAR', 'value')
+    assert get_user_env_var('TEST_VAR') == 'value'
 

--- a/utils.py
+++ b/utils.py
@@ -43,6 +43,26 @@ def set_user_env_var(name: str, value: str) -> None:
     )
 
 
+def get_user_env_var(name: str) -> str | None:
+    r"""Retrieve a user-level environment variable on Windows.
+
+    This helper reads the ``HKCU\Environment`` registry key so that values
+    configured globally are discovered even when the current process environment
+    does not include them (for example when running inside a virtual
+    environment).  On non-Windows platforms it simply falls back to
+    ``os.environ``.
+    """
+    if not sys.platform.startswith("win") or winreg is None:
+        return os.environ.get(name)
+    try:
+        reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment")
+        value, _ = winreg.QueryValueEx(reg_key, name)
+        winreg.CloseKey(reg_key)
+        return value
+    except FileNotFoundError:
+        return os.environ.get(name)
+
+
 def clean_unicode(obj):
     """Recursively strip Unicode control characters from nested structures."""
     if isinstance(obj, str):


### PR DESCRIPTION
## Summary
- add `get_user_env_var` helper to load API key from Windows user environment
- initialize Gemini client using environment variable or Windows registry value
- document Windows API key detection and test helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99f1ce21c8326bba04827a2a921cf