### PR TITLE
Stream TTS audio and queue narration sentences

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ google-genai
 pydantic>=2
 ttkbootstrap
 Pillow
+numpy
+sounddevice


### PR DESCRIPTION
## Summary
- Stream audio with sounddevice for low-latency narration and fall back to WAV playback when sounddevice isn't available
- Queue and speak individual sentences as they stream, clearing prior narration between turns
- Warm up TTS once and expose optional debug timing via `RPG_DEBUG_TTS`

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9c0b3c49c8326a0678c05aff39120