### PR TITLE
Switch to native audio dialog TTS and consolidate narration

### DIFF
--- a/model_costs.json
+++ b/model_costs.json
@@ -4,7 +4,7 @@
     "output_cost_per_token": 2.5e-6,
     "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
   },
-  "gemini-2.5-flash-preview-tts": {
+  "gemini-2.5-flash-preview-native-audio-dialog": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"


### PR DESCRIPTION
## Summary
- replace `gemini-live-2.5-flash-preview` with `gemini-2.5-flash-preview-native-audio-dialog`
- drop sentence-by-sentence narration queue and play full narration after each turn
- update model cost table for the new audio dialog model

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9ea5cbc748326bd5da7f135a3b638