### PR TITLE
Use only text input and audio output rates

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -1509,24 +1509,25 @@ class RPGGame:
         win.focus_force()
 
         # Compute costs based on external pricing data
-        text_rates  = MODEL_COSTS.get(MODEL, {})
+        text_rates = MODEL_COSTS.get(MODEL, {})
         audio_rates = MODEL_COSTS.get(AUDIO_MODEL, {})
         image_rates = MODEL_COSTS.get(IMAGE_MODEL, {})
 
         cost_text_prompt = (
-            self.total_prompt_tokens * text_rates.get("input_cost_per_token", 0)
+            self.total_prompt_tokens
+            * text_rates.get("text_input_cost_per_token", 0)
         )
         cost_text_completion = (
             self.total_completion_tokens
-            * text_rates.get("output_cost_per_token", 0)
+            * text_rates.get("audio_output_cost_per_token", 0)
         )
         cost_audio_prompt = (
             self.total_audio_prompt_tokens
-            * audio_rates.get("input_cost_per_token", 0)
+            * audio_rates.get("text_input_cost_per_token", 0)
         )
         cost_audio_output = (
             self.total_audio_output_tokens
-            * audio_rates.get("output_cost_per_token", 0)
+            * audio_rates.get("audio_output_cost_per_token", 0)
         )
         cost_images = (
             self.total_images * image_rates.get("output_cost_per_image", 0)

--- a/model_costs.json
+++ b/model_costs.json
@@ -1,16 +1,16 @@
 {
   "gemini-2.5-flash": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 2.5e-6,
-    "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+    "text_input_cost_per_token": 1.5e-7,
+    "audio_output_cost_per_token": 1.25e-6,
+    "source": "https://ai.google.dev/gemini-api/docs/pricing"
   },
   "gemini-2.5-flash-preview-native-audio-dialog": {
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+    "text_input_cost_per_token": 5e-7,
+    "audio_output_cost_per_token": 1.2e-5,
+    "source": "https://ai.google.dev/gemini-api/docs/pricing"
   },
   "imagen-4.0-fast-generate-001": {
     "output_cost_per_image": 0.02,
-    "source": "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+    "source": "https://ai.google.dev/gemini-api/docs/pricing"
   }
 }


### PR DESCRIPTION
## Summary
- simplify `model_costs.json` to contain only `text_input_cost_per_token` and `audio_output_cost_per_token`
- update cost calculations in `NilsRPG.py` to use these keys without fallbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba009fc78c83268449a0c20a248a31