### PR TITLE
feat: expose thinking budget in API menu

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -46,6 +46,7 @@ from utils import (
 IMAGE_GENERATION_ENABLED = False
 SOUND_ENABLED = True
 DEBUG_TTS = os.environ.get("RPG_DEBUG_TTS") == "1"
+THINKING_BUDGET = 0  # Default thinking budget for text model
 
 # --- Model configuration -------------------------------------------------
 # These constants declare which Gemini model powers each content stream.
@@ -737,7 +738,7 @@ class RPGGame:
                         response_mime_type="application/json",
                         response_schema=GameResponse,
                         thinking_config=types.ThinkingConfig(
-                            thinking_budget=0,          # Turns off thinking
+                            thinking_budget=THINKING_BUDGET,
                             include_thoughts=False      # Explicitly suppresses any thought fragments
                         )
                     ),
@@ -2031,6 +2032,7 @@ class RPGGame:
         image_model_var = tk.StringVar(value=IMAGE_MODEL)
         audio_model_var = tk.StringVar(value=AUDIO_MODEL)
         voice_var       = tk.StringVar(value=AUDIO_VOICE)
+        thinking_budget_var = tk.IntVar(value=THINKING_BUDGET)
 
         frm = ttk.Frame(win, padding=20)
         frm.pack(fill=tk.BOTH, expand=True)
@@ -2058,6 +2060,9 @@ class RPGGame:
 
         ttk.Label(frm, text="Sound Voice:").grid(row=6, column=0, sticky="w", pady=(10,0))
         ttk.Entry(frm, textvariable=voice_var, width=60).grid(row=6, column=2, sticky="w", pady=(10,0))
+
+        ttk.Label(frm, text="Thinking Budget:").grid(row=7, column=0, sticky="w", pady=(10,0))
+        ttk.Spinbox(frm, from_=0, to=4096, textvariable=thinking_budget_var, width=10).grid(row=7, column=2, sticky="w", pady=(10,0))
 
         btns = ttk.Frame(win, padding=(0,0,20,20))
         btns.pack(fill=tk.X, side=tk.BOTTOM)
@@ -2102,6 +2107,9 @@ class RPGGame:
 
             global AUDIO_VOICE
             AUDIO_VOICE = voice_var.get().strip()
+
+            global THINKING_BUDGET
+            THINKING_BUDGET = max(0, min(4096, int(thinking_budget_var.get())))
 
             win.destroy()
 

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ python NilsRPG.py
 
 The application will automatically read your `GEMINI_API_KEY` from the Windows
 user environment, even when running inside a virtual environment. You can also
-configure or update the key from the in‑game **API** menu.
+configure or update the key from the in‑game **API** menu, which also lets you
+set the text model's thinking budget (0‑4096) for deeper reasoning.


### PR DESCRIPTION
## Summary
- allow configuring text model thinking budget via the API dialog
- use selected thinking budget when generating content
- document the new option in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba11bd54a88326b881e7d18aca848a