### PR TITLE
feat: switch saves to pydantic validated json

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 """Data models used by the NilsRPG application."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class IdentitiesResponse(BaseModel):
@@ -63,4 +63,46 @@ class GameResponse(BaseModel):
     attributes: Attributes
     options: list[str]
     image_prompt: str
+
+
+class PaneSizes(BaseModel):
+    """Persisted geometry for the main, left and right panes."""
+
+    main_sash: int
+    left_sashes: list[int] = []
+    right_sashes: list[int] = []
+
+
+class SaveGame(BaseModel):
+    """Full representation of a saved game state."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    save_version: int = 1
+
+    identity: str | None = None
+    style: str | None = None
+    difficulty: str | None = None
+
+    turn: int
+    day: int
+    time: str
+    current_situation: str
+    environment: Environment
+    attributes: Attributes
+    inventory: list[InventoryItem]
+    perks_skills: list[PerkSkill]
+    options: list[str]
+
+    past_situations: list[str]
+    past_options: list[str]
+    past_days: list[int]
+    past_times: list[str]
+
+    previous_image_prompt: str | None = None
+    character_id: str
+    pane_sizes: PaneSizes | None = None
+    story_text: str | None = None
+    scene_image_b64: str | None = None
+
 


### PR DESCRIPTION
## Summary
- replace pickle save files with Pydantic models serialized to JSON
- load saves with validation and base64-encoded images
- show thumbnails and metadata from JSON saves

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba8f590e9883268b9203623f6e183c