### PR TITLE
Centralize pricing logic

### DIFF
--- a/billing.py
+++ b/billing.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Mapping, Tuple
+
+
+@dataclass
+class Rates:
+    """Pricing information for a model.
+
+    All fields default to ``0`` so missing rates are treated as free.
+    """
+    text_input_cost_per_token: float = 0.0
+    text_output_cost_per_token: float = 0.0
+    audio_output_cost_per_token: float = 0.0
+    output_cost_per_image: float = 0.0
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, float]) -> "Rates":
+        return cls(
+            text_input_cost_per_token=data.get("text_input_cost_per_token", 0.0),
+            text_output_cost_per_token=data.get("text_output_cost_per_token", 0.0),
+            audio_output_cost_per_token=data.get("audio_output_cost_per_token", 0.0),
+            output_cost_per_image=data.get("output_cost_per_image", 0.0),
+        )
+
+
+def compute_text_costs(prompt_tokens: int, completion_tokens: int, rates: Mapping[str, float]) -> Tuple[float, float, float]:
+    """Return (prompt_cost, completion_cost, total) for text tokens."""
+    r = Rates.from_mapping(rates)
+    cost_prompt = prompt_tokens * r.text_input_cost_per_token
+    cost_completion = completion_tokens * r.text_output_cost_per_token
+    return cost_prompt, cost_completion, cost_prompt + cost_completion
+
+
+def compute_audio_costs(prompt_tokens: int, output_tokens: int, rates: Mapping[str, float]) -> Tuple[float, float, float]:
+    """Return (prompt_cost, output_cost, total) for audio tokens."""
+    r = Rates.from_mapping(rates)
+    cost_prompt = prompt_tokens * r.text_input_cost_per_token
+    cost_output = output_tokens * r.audio_output_cost_per_token
+    return cost_prompt, cost_output, cost_prompt + cost_output
+
+
+def compute_image_costs(image_count: int, rates: Mapping[str, float]) -> float:
+    """Return total cost for ``image_count`` images."""
+    r = Rates.from_mapping(rates)
+    return image_count * r.output_cost_per_image

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1,0 +1,38 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import billing
+
+
+def test_compute_text_costs():
+    rates = {"text_input_cost_per_token": 0.1, "text_output_cost_per_token": 0.2}
+    cp, cc, total = billing.compute_text_costs(10, 5, rates)
+    assert cp == 1.0
+    assert cc == 1.0
+    assert total == 2.0
+
+
+def test_compute_audio_costs():
+    rates = {"text_input_cost_per_token": 0.1, "audio_output_cost_per_token": 0.3}
+    cp, co, total = billing.compute_audio_costs(10, 5, rates)
+    assert cp == 1.0
+    assert co == 1.5
+    assert total == 2.5
+
+
+def test_compute_image_costs():
+    rates = {"output_cost_per_image": 0.5}
+    assert billing.compute_image_costs(3, rates) == 1.5
+
+
+def test_text_completion_uses_text_output_rate():
+    rates = {
+        "text_input_cost_per_token": 0.0,
+        "text_output_cost_per_token": 0.2,
+        "audio_output_cost_per_token": 0.9,
+    }
+    _, completion_cost, _ = billing.compute_text_costs(0, 1, rates)
+    assert completion_cost == rates["text_output_cost_per_token"]
+    assert completion_cost != rates["audio_output_cost_per_token"]


### PR DESCRIPTION
## Summary
- Introduce `billing` module with helpers to compute text, audio, and image costs.
- Refactor `_show_costs_tokens` to use centralized billing functions, eliminating inline rate math.
- Add comprehensive tests for billing helpers and a regression test guarding text output rate usage.

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baaa51c2888326a44bf9670e7e51ce