### PR TITLE
Gracefully handle audio write errors

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -1158,7 +1158,12 @@ class RPGGame:
                         arr = np.frombuffer(data, dtype=np.int16)
                         # Offload the blocking write via the default threadpool so
                         # asyncio can continue replying to websocket pings.
-                        await loop.run_in_executor(None, sd_stream.write, arr)
+                        try:
+                            await loop.run_in_executor(None, sd_stream.write, arr)
+                        except Exception as e:
+                            print("TTS audio write warning:", e)
+                            # Soft-break the loop so we can close the stream cleanly
+                            break
                 with self._audio_stream_lock:
                     sd_stream.stop()
                     sd_stream.close()


### PR DESCRIPTION
## Summary
- Harden TTS audio streaming by wrapping blocking sounddevice writes in a try/except.
- On write failure, log a warning and exit the receive loop so the audio stream closes cleanly.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bacfb640408326a932fa6bd9d39ad0