### PR TITLE
Refactor Google GenAI API access into testable module

### DIFF
--- a/genai_api.py
+++ b/genai_api.py
@@ -1,0 +1,72 @@
+"""Utilities for working with the Google GenAI client.
+
+This module centralises API key resolution and client creation so that the
+rest of the application can remain agnostic of the underlying SDK. Having a
+single, easily mocked location for API access greatly simplifies testing and
+development.
+"""
+from __future__ import annotations
+
+import os
+from google import genai
+from google.genai import types, errors
+
+from utils import get_user_env_var
+
+# Cached client instance and the key used to create it
+client: genai.Client | None = None
+_client_key: str | None = None
+
+def resolve_api_key() -> str:
+    """Return the best available Gemini API key.
+
+    The environment variable ``GEMINI_API_KEY`` takes precedence but we fall
+    back to :func:`utils.get_user_env_var` for user-level variables.  When a key
+    is found it is written back into ``os.environ`` so that downstream code can
+    rely on it.
+    """
+    key = (
+        os.environ.get("GEMINI_API_KEY")
+        or get_user_env_var("GEMINI_API_KEY")
+        or ""
+    ).strip()
+    if key:
+        os.environ["GEMINI_API_KEY"] = key
+    return key
+
+def ensure_client() -> genai.Client | None:
+    """Return a Gemini client for the current environment key.
+
+    Lazily creates or updates the cached :class:`google.genai.Client` when the
+    API key changes.  ``None`` is returned if no key is available.
+    """
+    global client, _client_key
+    key = resolve_api_key()
+    if not key:
+        client = None
+        _client_key = None
+        return None
+    if client is None or key != _client_key:
+        client = genai.Client(api_key=key)
+        _client_key = key
+    return client
+
+def set_client_for_key(new_client: genai.Client, key: str) -> None:
+    """Replace the cached client with ``new_client`` bound to ``key``.
+
+    Primarily used when the application validates a new API key and wants to
+    reuse the instantiated client.
+    """
+    global client, _client_key
+    client = new_client
+    _client_key = key
+
+__all__ = [
+    "client",
+    "ensure_client",
+    "resolve_api_key",
+    "set_client_for_key",
+    "types",
+    "errors",
+    "genai",
+]

--- a/tests/test_nilsrpg_helpers.py
+++ b/tests/test_nilsrpg_helpers.py
@@ -6,6 +6,7 @@ import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import NilsRPG as nr
+import genai_api as ga
 
 
 def test_parse_world_extracts_sections():
@@ -20,13 +21,13 @@ def test_parse_world_extracts_sections():
 def test_resolve_api_key_precedence(monkeypatch):
     """Environment variables take precedence over user-level variables."""
     monkeypatch.setenv("GEMINI_API_KEY", "env_key")
-    monkeypatch.setattr(nr, "get_user_env_var", lambda name: "user_key")
-    assert nr._resolve_api_key() == "env_key"
+    monkeypatch.setattr(ga, "get_user_env_var", lambda name: "user_key")
+    assert ga.resolve_api_key() == "env_key"
     assert os.environ["GEMINI_API_KEY"] == "env_key"
 
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-    monkeypatch.setattr(nr, "get_user_env_var", lambda name: "user_key")
-    assert nr._resolve_api_key() == "user_key"
+    monkeypatch.setattr(ga, "get_user_env_var", lambda name: "user_key")
+    assert ga.resolve_api_key() == "user_key"
     assert os.environ["GEMINI_API_KEY"] == "user_key"
 
 
@@ -36,24 +37,24 @@ def test_ensure_client_reuses_and_updates(monkeypatch):
         def __init__(self, api_key):
             self.api_key = api_key
 
-    monkeypatch.setattr(nr, "genai", types.SimpleNamespace(Client=DummyClient))
-    monkeypatch.setattr(nr, "get_user_env_var", lambda name: None)
+    monkeypatch.setattr(ga, "genai", types.SimpleNamespace(Client=DummyClient))
+    monkeypatch.setattr(ga, "get_user_env_var", lambda name: None)
 
     # reset globals
-    nr.client = None
-    nr._client_key = None
+    ga.client = None
+    ga._client_key = None
 
     monkeypatch.setenv("GEMINI_API_KEY", "key1")
-    c1 = nr._ensure_client()
+    c1 = ga.ensure_client()
     assert isinstance(c1, DummyClient)
     assert c1.api_key == "key1"
 
     # same key returns same instance
-    c2 = nr._ensure_client()
+    c2 = ga.ensure_client()
     assert c2 is c1
 
     # changing key creates new client
     monkeypatch.setenv("GEMINI_API_KEY", "key2")
-    c3 = nr._ensure_client()
+    c3 = ga.ensure_client()
     assert c3 is not c1
     assert c3.api_key == "key2"


### PR DESCRIPTION
## Summary
- isolate Google GenAI client management into new `genai_api` module
- update `NilsRPG` to consume shared helpers for text, audio and image requests
- adjust tests to cover the new module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb22b3a1108326af53a9d771f72c54