### PR TITLE
Remove redundant os.path import

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -7,7 +7,6 @@ role‑playing experience.
 
 import json
 import os
-import os.path
 import base64
 import re
 import sys


### PR DESCRIPTION
## Summary
- Drop standalone `import os.path` from `NilsRPG.py`
- Ensure file modification times retrieved via `os.path` on the `os` module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b71141083269269e9ddb2de3434