### PR TITLE
Fix PaneSizes list defaults with Field factory

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 """Data models used by the NilsRPG application."""
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class IdentitiesResponse(BaseModel):
@@ -69,8 +69,8 @@ class PaneSizes(BaseModel):
     """Persisted geometry for the main, left and right panes."""
 
     main_sash: int
-    left_sashes: list[int] = []
-    right_sashes: list[int] = []
+    left_sashes: list[int] = Field(default_factory=list)
+    right_sashes: list[int] = Field(default_factory=list)
 
 
 class SaveGame(BaseModel):


### PR DESCRIPTION
## Summary
- avoid mutable default lists in PaneSizes by using `Field(default_factory=list)`
- import `Field` from pydantic for new defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c70620483269cee8b44d5bf9760