### PR TITLE
Handle zero response token counts

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,3 +70,12 @@ def test_get_response_tokens_handles_legacy_and_new_fields():
     # When no relevant field exists, result should be zero
     assert get_response_tokens(UsageMetadata()) == 0
 
+
+def test_get_response_tokens_returns_zero_when_explicitly_zero():
+    """Ensure zero response_token_count is respected without fallback."""
+
+    both = type(
+        "Usage", (), {"response_token_count": 0, "candidates_token_count": 9}
+    )()
+    assert get_response_tokens(both) == 0
+

--- a/utils.py
+++ b/utils.py
@@ -88,11 +88,17 @@ def get_response_tokens(usage) -> int:
     if usage is None:  # pragma: no cover - defensive
         return 0
 
-    return (
-        getattr(usage, "response_token_count", None)
-        or getattr(usage, "candidates_token_count", 0)
-        or 0
-    )
+    if hasattr(usage, "response_token_count") and getattr(
+        usage, "response_token_count"
+    ) is not None:
+        return getattr(usage, "response_token_count")
+
+    if hasattr(usage, "candidates_token_count") and getattr(
+        usage, "candidates_token_count"
+    ) is not None:
+        return getattr(usage, "candidates_token_count")
+
+    return 0
 
 
 def load_embedded_fonts() -> None:


### PR DESCRIPTION
## Summary
- Ensure `get_response_tokens` respects `response_token_count` even when zero
- Add regression test for zero-valued `response_token_count`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e2e0e1483269c01bccf49a70e9e