### PR TITLE
Fix image generation parameter names for Google GenAI

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -1305,8 +1305,8 @@ class RPGGame:
                 config=types.GenerateImagesConfig(
                     number_of_images=1,
                     include_rai_reason=True,
-                    aspectRatio="16:9",
-                    personGeneration="ALLOW_ADULT"
+                    aspect_ratio="16:9",
+                    person_generation="ALLOW_ADULT"
                 )
             )
             self.last_image_duration = time.time() - start


### PR DESCRIPTION
## Summary
- replace deprecated `aspectRatio` and `personGeneration` params with `aspect_ratio` and `person_generation`
- verify updated parameters work with `GenerateImagesConfig`

## Testing
- `python - <<'PY' ...`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb405a206c83269702200875c215f7