### PR TITLE
Ensure registry key closed in get_user_env_var

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -56,9 +56,11 @@ def get_user_env_var(name: str) -> str | None:
         return os.environ.get(name)
     try:
         reg_key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Environment")
-        value, _ = winreg.QueryValueEx(reg_key, name)
-        winreg.CloseKey(reg_key)
-        return value
+        try:
+            value, _ = winreg.QueryValueEx(reg_key, name)
+            return value
+        finally:
+            winreg.CloseKey(reg_key)
     except FileNotFoundError:
         return os.environ.get(name)
 


### PR DESCRIPTION
## Summary
- ensure `get_user_env_var` closes registry key even when `QueryValueEx` fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb49b52480832685aa2a32de3f2577