### PR TITLE
Ensure menu closes after loading a game

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -1832,6 +1832,12 @@ class RPGGame:
 
     def _load_game_from_path(self, path):
         """Load game state from the user's chosen save file."""
+        # Ensure any menu or load dialog is closed before restoring state
+        if hasattr(self, "menu_win") and self.menu_win.winfo_exists():
+            self.menu_win.destroy()
+        if hasattr(self, "load_win") and self.load_win.winfo_exists():
+            self.load_win.destroy()
+
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = SaveGame.model_validate_json(f.read())


### PR DESCRIPTION
## Summary
- Close any open menu or load-game dialogs before restoring game state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb542955bc83269b88f7cc1e9d7a7e