### PR TITLE
Fix async TTS streaming

### DIFF
--- a/NilsRPG.py
+++ b/NilsRPG.py
@@ -1079,7 +1079,7 @@ class RPGGame:
             # ``AttributeError`` because ``responses`` no longer exists on the
             # async client.  Use ``models.generate_content_stream`` instead to
             # obtain an async iterator of audio chunks.
-            stream = client.aio.models.generate_content_stream(
+            stream = await client.aio.models.generate_content_stream(
                 model=AUDIO_MODEL,
                 contents=[
                     types.Content(

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -50,7 +50,7 @@ def test_speak_situation_streams_via_models(monkeypatch):
     # Track whether ``generate_content_stream`` was invoked.
     called = {"flag": False}
 
-    def gen_content_stream(**_):
+    async def gen_content_stream(**_):
         called["flag"] = True
         return _dummy_stream()
 


### PR DESCRIPTION
## Summary
- await `generate_content_stream` to handle async TTS iterator
- update TTS test stub to mimic async stream

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5ed1e8d08326bcfe48fdcadbb11e